### PR TITLE
Update to Android SDK 35 and modernize build configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+NyanDroid is an Android live wallpaper featuring the famous Nyan Cat as "NyanDroid" flying through space. The project is written in Kotlin and targets Android devices with live wallpaper functionality.
+
+## Architecture
+
+- **Main Activity**: `NyanActivity.kt` - Fullscreen preview activity with audio playback
+- **Live Wallpaper Service**: `NyanPaper.kt` - Wallpaper service implementation
+- **Animation Core**: `NyanAnimation.kt` - Handles sprite animation and rendering logic
+- **Custom View**: `NyanView.kt` - SurfaceView for displaying animations
+- **Sprite Components**: Located in `sprites/` directory
+  - `NyanDroid.kt` - Main character sprite
+  - `Rainbow.kt` - Rainbow trail sprite
+  - `Stars.kt` - Background star animations
+- **Settings**: `NyanSettingsActivity.kt` and `NyanSettingsFragment.kt` - User preferences
+
+The app uses a custom animation engine that renders sprites to a SurfaceView with frame-based animation cycles.
+
+## Build and Development Commands
+
+**Prerequisites**: Ensure Java 17 is installed and `JAVA_HOME` is set correctly:
+```bash
+export JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.15/libexec/openjdk.jdk/Contents/Home
+```
+
+**Main Build Tasks**:
+- `./gradlew build` - Full build including tests
+- `./gradlew assembleDebug` - Build debug APK
+- `./gradlew assembleRelease` - Build release APK (with ProGuard/R8)
+- `./gradlew clean` - Clean build directory
+
+**Installation and Testing**:
+- `./gradlew installDebug` - Install debug build to connected device
+- `./gradlew connectedDebugAndroidTest` - Run instrumentation tests on device
+- `./gradlew testDebugUnitTest` - Run unit tests for debug build
+- `./gradlew lint` - Run Android lint checks
+- `./gradlew check` - Run all verification tasks
+
+**Useful Development Tasks**:
+- `./gradlew dependencies` - Show project dependencies
+- `./gradlew signingReport` - Display signing configuration
+- `./gradlew tasks` - List all available tasks
+
+## Project Structure
+
+- **Target SDK**: 35 (Android 15)
+- **Min SDK**: 30 (Android 11)
+- **Compile SDK**: 35
+- **Build Tools**: 35.0.0
+- **Gradle**: 8.11.1
+- **Android Gradle Plugin**: 8.9.0
+- **Kotlin**: 1.9.23
+- **Dependencies**: androidx.appcompat, androidx.preference, Kotlin stdlib
+
+## Key Technical Details
+
+- Uses `SurfaceView` for efficient animation rendering
+- Implements Android's `WallpaperService.Engine` for live wallpaper functionality
+- Includes audio playback with looping background music (`dyan_loop.mp3`)
+- Supports immersive fullscreen mode with transparent system bars
+- Uses ProGuard/R8 for release builds with code shrinking and obfuscation
+- Preference-based settings system for user customization

--- a/NyanDroid/build.gradle.kts
+++ b/NyanDroid/build.gradle.kts
@@ -11,9 +11,9 @@ allprojects {
 }
 
 android {
-    compileSdk = 34
+    compileSdk = 35
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 35
         minSdk = 30
         versionCode = 17
         applicationId = "com.powerje.nyan"
@@ -32,7 +32,7 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    buildToolsVersion = "34.0.0"
+    buildToolsVersion = "35.0.0"
 }
 
 dependencies {

--- a/NyanDroid/proguard-rules.pro
+++ b/NyanDroid/proguard-rules.pro
@@ -1,0 +1,32 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.kts.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+
+# Keep wallpaper service
+-keep class com.powerje.nyan.NyanPaper { *; }
+-keep class com.powerje.nyan.NyanPaper$NyanEngine { *; }
+
+# Keep activity
+-keep class com.powerje.nyan.NyanActivity { *; }
+
+# Keep settings
+-keep class com.powerje.nyan.NyanSettingsActivity { *; }
+-keep class com.powerje.nyan.NyanSettingsFragment { *; }

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,10 @@ buildscript {
     ext.kotlin_version = '1.9.23'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:8.3.2'
+        classpath 'com.android.tools.build:gradle:8.9.0'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 14 21:39:01 EST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Updates project to Android SDK 35 (Android 15) for Google Play 2025 compliance
- Modernizes build configuration with latest Gradle and Android Gradle Plugin versions
- Fixes deprecated JCenter repository usage
- Adds comprehensive documentation and ProGuard rules

## Changes Made
- **Android SDK**: Updated compileSdk and targetSdk from 34 to 35
- **Build Tools**: Updated from 34.0.0 to 35.0.0
- **Gradle**: Updated wrapper from 8.6 to 8.11.1
- **Android Gradle Plugin**: Updated from 8.3.2 to 8.9.0
- **Repository**: Replaced deprecated `jcenter()` with `mavenCentral()`
- **ProGuard**: Added `proguard-rules.pro` file for release builds
- **Documentation**: Added `CLAUDE.md` for future development guidance

## Compliance Benefits
✅ Meets Google Play 2025 requirements (apps must target API 35)
✅ Ready for publication on Google Play Store
✅ Updated to latest stable Android 15 features
✅ Future-proofed build configuration

## Test Results
- ✅ Debug builds: Working perfectly
- ✅ Release builds: Working with ProGuard/R8 optimization
- ✅ All lint checks pass
- ✅ No build errors or deprecation warnings

🤖 Generated with [Claude Code](https://claude.ai/code)