### PR TITLE
Fix off-center rendering on some devices

### DIFF
--- a/NyanDroid/src/main/java/com/powerje/nyan/NyanAnimation.kt
+++ b/NyanDroid/src/main/java/com/powerje/nyan/NyanAnimation.kt
@@ -16,7 +16,8 @@ class NyanAnimation(private val context: Context, private val holder: SurfaceHol
     }
     private val sharedPreferences: SharedPreferences = context.getSharedPreferences(context.getString(R.string.shared_preferences_name), 0)
 
-    private var hasCenteredImages: Boolean = false
+    private var lastCanvasWidth: Int = 0
+    private var lastCanvasHeight: Int = 0
     private var hasLoadedImages: Boolean = false
     private var preferencesChanged: Boolean = false
 
@@ -76,7 +77,8 @@ class NyanAnimation(private val context: Context, private val holder: SurfaceHol
     }
 
     override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
-        hasCenteredImages = false
+        lastCanvasWidth = 0
+        lastCanvasHeight = 0
         preferencesChanged = true
     }
 
@@ -119,15 +121,17 @@ class NyanAnimation(private val context: Context, private val holder: SurfaceHol
         if (preferencesChanged) {
             setupAnimations()
             preferencesChanged = false
-            hasCenteredImages = false
+            lastCanvasWidth = 0
+            lastCanvasHeight = 0
         }
 
         frameCount++
         if (c != null && hasLoadedImages) {
-            if (!hasCenteredImages) {
+            if (c.width != lastCanvasWidth || c.height != lastCanvasHeight) {
                 rainbow!!.setCenter(c.width / 2, c.height / 2)
                 nyanDroid!!.setCenter(c.width / 2, c.height / 2)
-                hasCenteredImages = true
+                lastCanvasWidth = c.width
+                lastCanvasHeight = c.height
             }
 
             c.drawColor(ContextCompat.getColor(context, R.color.nyanblue))


### PR DESCRIPTION
## Summary

- Replaces `hasCenteredImages` boolean flag with `lastCanvasWidth`/`lastCanvasHeight` dimension tracking
- Re-centers sprites whenever canvas dimensions actually change, rather than relying solely on `surfaceChanged` callback
- Two int comparisons per frame; `setCenter` only called when dimensions differ

Fixes #10

## Test plan

- [x] Verify wallpaper stays centered after rotation
- [x] Verify wallpaper stays centered during home screen page swipes
- [x] Verify wallpaper stays centered in split-screen / multi-window mode
- [x] Verify no visible performance regression (animation smoothness, battery)